### PR TITLE
Fix duplicate virtualenv declaration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -279,8 +279,8 @@ class puppetboard(
   }
 
   if $manage_virtualenv and !defined(Package[$::puppetboard::params::virtualenv]) {
-    package { $::puppetboard::params::virtualenv:
-      ensure => installed,
+    class { 'python':
+      virtualenv => 'present',
     }
   }
 


### PR DESCRIPTION
Package python-virtualenv is declared in the python module, which puppetboard uses. This will cause an error when applying the catalog:

Error: Failed to apply catalog: Cannot alias Package[virtualenv] to ["python-virtualenv", :apt] at /etc/puppetlabs/code/environments/production/modules/python/manifests/install.pp:53; resource ["Package", "python-virtualenv", :apt] already declared at /etc/puppetlabs/code/environments/production/modules/puppetboard/manifests/init.pp:282

This fixes this issue, virtualenv is installed successfully.