### PR TITLE
Ubuntu exceptions 

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,9 +8,14 @@ class puppetboard::params {
 
   case $::osfamily {
     'Debian': {
+      if $::operatingsystem == ubuntu {
+        $apache_confd = '/etc/apache2/conf-enabled'
+      } else {
       $apache_confd   = '/etc/apache2/conf.d'
+      }
       $apache_service = 'apache2'
     }
+
     'RedHat': {
       $apache_confd   = '/etc/httpd/conf.d'
       $apache_service = 'httpd'


### PR DESCRIPTION
Ubuntu uses /etc/apache2/conf-enabled for custom config. This adds an exception for Ubuntu in the Debian family case