### PR TITLE
Release 2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Release 2.8.1
+
+* Fix old Versionnumber in metadata.json
+
 # Release 2.8.0
 
 * Official drop Ruby 1.8 support

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-puppetboard",
-  "version": "2.7.6-rc0",
+  "version": "2.8.1",
   "author": "voxpupuli",
   "summary": "Install and configure PuppetBoard",
   "license": "Apache-2.0",


### PR DESCRIPTION
The last release didn't went very well. blacksmith detected the old release name in metadata..json and tried to release our 2.8 changes as 2.7.5. The build got cancelled. This PR should create a proper release.